### PR TITLE
obs_point indexing, land masks, observation types

### DIFF
--- a/obsprep/interp.py
+++ b/obsprep/interp.py
@@ -2,7 +2,7 @@ import pyresample as pr
 import numpy as np
 
 def get_interp_points(lons, lats,
-                      grid_lon_wm_flat, grid_lat_wm_flat, nneighbours=4,
+                      grid_lon_flat, grid_lat_flat, nneighbours=4,
                       max_target_grid_radius = int(15e4), max_attempts=10, radius_factor=1.5,
                      ):
     """
@@ -14,9 +14,9 @@ def get_interp_points(lons, lats,
         Longitudes of ungridded points.
     lats : array-like
         Latitudes of ungridded points.
-    grid_lon_wm_flat : array-like
+    grid_lon_flat : array-like
         Longitudes of the source grid (flattened).
-    grid_lat_wm_flat : array-like
+    grid_lat_flat : array-like
         Latitudes of the source grid (flattened).
     nneighbours : int, optional
         Number of nearest neighbours to find (default is 4).
@@ -33,16 +33,11 @@ def get_interp_points(lons, lats,
     )
     
     source_grid = pr.geometry.SwathDefinition(
-        lons=grid_lon_wm_flat, lats=grid_lat_wm_flat
+        lons=grid_lon_flat, lats=grid_lat_flat
     )
 
     invalid_search = True
     attempt = 0
-
-    # if nneighbours == 8:
-    #     n_search = 4
-    # else:
-    #     n_search = nneighbours
 
     while (invalid_search) & (attempt < max_attempts):
       valid_input_index, valid_output_index, index_array, distance_array = pr.kd_tree.get_neighbour_info(
@@ -61,15 +56,8 @@ def get_interp_points(lons, lats,
     if attempt == max_attempts:
         raise ValueError(f"Couldn't find valid interp points in {max_attempts} attempts")
 
-    # edge case: kdtree can return grid_lon_wm_flat.size as a valid index
-    index_array[index_array == grid_lon_wm_flat.size] -= 1
-
-    # if nneighbours == 8:
-    #     valid_input_index = np.tile(valid_input_index,2)
-    #     valid_output_index = np.tile(valid_output_index, 2)
-    #     index_array = np.tile(index_array, 2) # nearest grid index
-    #     distance_array = np.tile(distance_array, 2)
-        
+    # edge case: kdtree can return grid_lon_flat.size as a valid index
+    index_array[index_array == grid_lon_flat.size] -= 1
 
     return (valid_input_index, valid_output_index, index_array, distance_array, max_target_grid_radius)
     

--- a/obsprep/prep.py
+++ b/obsprep/prep.py
@@ -1,8 +1,8 @@
 import copy
 import xarray as xr
 import numpy as np
-from ecco_v4_py.llc_array_conversion import llc_tiles_to_faces, llc_tiles_to_compact
-from obsprep.utils import patchface3D_5f_to_wrld, compact2worldmap, get_sample_type
+from ecco_v4_py.llc_array_conversion import llc_tiles_to_faces, llc_faces_to_tiles
+from obsprep.utils import *
 from obsprep.interp import *
 from obsprep.time_utils import get_obs_datetime
 
@@ -50,7 +50,7 @@ class Prep:
 
     def get_obs_point(self, lons=None, lats=None, depths=None,
                                 grid_type='sphericalpolar', grid_ds=None,
-                                num_interp_points=1, sNx=30, sNy=30, max_target_grid_radius=None,
+                                num_interp_points=1, sNx=30, sNy=30, max_target_grid_radius=1e5,
                                ):
         """
         Find the nearest grid point for given ungridded longitude and latitude coordinates.
@@ -133,28 +133,14 @@ class Prep:
         elif (num_interp_points not in [1, 4, 8]) & (self.pkg_str == 'obs'):
             raise ValueError(f"Invalid num_interp_points '{num_interp_points}'. Must be either 1, 4, or 8 for pkg/obsfit.")
             
-        # add attributes relevant to interpolation field creation
-        self.xc = grid_ds.XC.values
-        self.yc = grid_ds.YC.values
-        self.rc = grid_ds.Z.values
-        self.maskc = grid_ds.maskC.values
-        self.maskw = grid_ds.maskW.values
-        self.masks = grid_ds.maskS.values
+        # add grid dataset to Prep
+        self.grid_ds = grid_ds
+        nx = len(self.grid_ds.i) 
+        self.nz = len(self.grid_ds.Z)
 
-        # same xc, yc in worldmap form for later        
-        nx = len(self.xc[0, 0, :]) # (last two dimensions of xc with shape (ntile, nx, nx)
-        self.nz = len(self.rc)
-        self.xc_wm = compact2worldmap(llc_tiles_to_compact(self.xc, less_output=True), nx, 1)[0, :, :]
-        self.yc_wm = compact2worldmap(llc_tiles_to_compact(self.yc, less_output=True), nx, 1)[0, :, :]
-        self.maskc_wm = compact2worldmap(llc_tiles_to_compact(self.maskc, less_output=True), nx, self.nz)
-        self.maskw_wm = compact2worldmap(llc_tiles_to_compact(self.maskw, less_output=True), nx, self.nz)
-        self.masks_wm = compact2worldmap(llc_tiles_to_compact(self.masks, less_output=True), nx, self.nz)
-        
-       # self.mask_wm = compact2worldmap(llc_tiles_to_compact(self.mask, less_output=True), nx, 1)[0, :, :]
-        
         # set nearest neighbours search radius
-        if max_target_grid_radius == None:
-            max_target_grid_radius = np.max(np.abs([grid_ds.dxG.values, grid_ds.dyG.values]))
+        if ('dyG' in grid_ds.coords) and ('dxG' in grid_ds.coords):
+            max_target_grid_radius = np.max(np.abs([self.grid_ds.dxG.values, self.grid_ds.dyG.values]))
         self.max_target_grid_radius = max_target_grid_radius
 
         self.num_interp_points = num_interp_points
@@ -163,7 +149,7 @@ class Prep:
         self.dims_interp = self.dims_obs + ['iINTERP']
 
         # run interpolation routine
-        self.obs_points = self.interp() # indices in WM view 
+        self.obs_points = self.interp() # indices in 13-face view 
 
         # add fields to ds
         self.interp_str = 'prof' if self.pkg_str == 'prof' else 'sample'
@@ -176,7 +162,7 @@ class Prep:
         self.ds[self.obs_point_str] = (self.dims_interp, self.obs_points)
 
         # add grid interp fields
-        self.get_sample_interp_info() 
+        self.get_sample_interp_info()
 
     def interp(self):
         """
@@ -187,29 +173,57 @@ class Prep:
         index_array : ndarray
             Array containing indices of the nearest grid points for the given observation points.
         """
+
+        # dataset might feature multiple sample types
+        # need to loop through each possible one and search along
+        # correct coordinates [X/Y][C/G] and mask[C/W/S]
+        mask_sfxs = get_mask_sfx_from_sample_type(self.ds.sample_type.values)
+        mask_sfxs_uniq = np.unique(mask_sfxs)
+
+        index_arrays = dict.fromkeys(mask_sfxs)
+        interp_distances = dict.fromkeys(mask_sfxs)
         
-        # turn from tiles to worldmap   
-        valid_input_index, valid_output_index, index_array, distance_array, max_target_grid_radius =\
-            get_interp_points(
-                self.ds[self.lon_str],
-                self.ds[self.lat_str],
-                self.xc_wm.ravel(),
-                self.yc_wm.ravel(),
-                #nneighbours=self.num_interp_points,
-                nneighbours=self.nneighbours_horizontal,
-                max_target_grid_radius=self.max_target_grid_radius
-            )
-        
-        if self.num_interp_points == 8:
-            valid_input_index = np.tile(valid_input_index,2)
-            valid_output_index = np.tile(valid_output_index, 2)
-            index_array = np.tile(index_array, 2) # nearest grid index
-            distance_array = np.tile(distance_array, 2)
+        for mask_sfx in mask_sfxs_uniq:
+            mask = self.grid_ds[f'mask{mask_sfx}']
+            grid_lon_str, grid_lat_str = (grid_map[mask_sfx][key] for key in ['grid_lon', 'grid_lat'])
             
-        self.interp_distance = distance_array
-        self.max_target_grid_radius = max_target_grid_radius
+            grid_lon = self.grid_ds[grid_lon_str].values.ravel()
+            grid_lat = self.grid_ds[grid_lat_str].values.ravel()
+            
+            # turn from tiles to worldmap   
+            valid_input_index, valid_output_index, index_array, distance_array, max_target_grid_radius =\
+                get_interp_points(
+                    self.ds[self.lon_str],
+                    self.ds[self.lat_str],
+                    grid_lon,
+                    grid_lat,
+                    #nneighbours=self.num_interp_points,
+                    nneighbours=self.nneighbours_horizontal,
+                    max_target_grid_radius=self.max_target_grid_radius
+                )
+            if self.num_interp_points == 8:
+                valid_input_index = np.tile(valid_input_index,2)
+                valid_output_index = np.tile(valid_output_index, 2)
+                index_array = np.tile(index_array, 2) # nearest grid index
+                distance_array = np.tile(distance_array, 2)
+            index_arrays[mask_sfx] = index_array
+            interp_distances[mask_sfx] = distance_array
+
+#            self.max_target_grid_radius = max_target_grid_radius
+            print(mask_sfx, self.max_target_grid_radius)
+
+        # now we have up to three index arrays, one for each mask
+        # organize them into a single index_array
+        if self.num_interp_points == 1:
+            for sfx in mask_sfxs_uniq:
+                index_arrays[sfx] = index_arrays[sfx][:, None]
+                interp_distances[sfx] = interp_distances[sfx][:, None]
+        index_array_out = np.array([index_arrays[sfx][i, :] for i, sfx in enumerate(mask_sfxs)])
+        interp_distance = np.array([interp_distances[sfx][i, :] for i, sfx in enumerate(mask_sfxs)])
+
+        self.interp_distance = interp_distance
         
-        return index_array
+        return index_array_out
         
         
     def get_sample_interp_info(self):
@@ -221,8 +235,8 @@ class Prep:
             return {face: np.zeros_like(xgrid[face]) for face in range(1, 6)}
         
         # transform xc and yc from worldmap back to 5faces
-        xc_5faces = llc_tiles_to_faces(self.xc, less_output=True)
-        yc_5faces = llc_tiles_to_faces(self.yc, less_output=True)
+        xc_5faces = llc_tiles_to_faces(self.grid_ds.XC, less_output=True)
+        yc_5faces = llc_tiles_to_faces(self.grid_ds.YC, less_output=True)
         
         xc_5faces.copy()
         yc_5faces.copy()
@@ -254,18 +268,13 @@ class Prep:
         # Grab values of these fields at [prof/obs]_point 
         # save tiles in worldmap views for interp later
         # probably a bad idea memory-wise for high res grids
-        tile_fields_wm = dict.fromkeys(tile_keys)
 
         for tile_key, tile_field in tile_fields.items():
             tile_field = {iF: tile_field[iF][None, :] for iF in tile_field}
 
-            # TODO: 
-            #     Replace with ecco.faces_to_tiles
-            #     then tiles_to_world
-            tile_field_wm = patchface3D_5f_to_wrld(tile_field)
-            tile_field_at_obs_point = tile_field_wm.ravel()[self.obs_points]
-
-            tile_fields_wm[tile_key] = tile_field_wm
+            # convert to 13-face format, since obs_point are indices relative to that view's what obs_point indices are in reference to
+            tile_field_13f = llc_faces_to_tiles(tile_field, less_output=True)
+            tile_field_at_obs_point = tile_field_13f.ravel()[self.obs_points]
 
             # profiles default: make singleton iINTERP dimension
             #                   set sample_interp_weight np.ones
@@ -276,12 +285,9 @@ class Prep:
             # set interp field in dataset
             self.ds[f'{self.interp_str}_interp_{tile_key}'] = (self.dims_interp, tile_field_at_obs_point)
 
-            # save tile_fields
-            self.tile_fields_wm = tile_fields_wm
-
         # set interp_k field in dataset
         if self.pkg_str == 'obs': 
-            sample_interp_k = get_sample_interp_k(self.rc, self.ds[self.depth_str], self.num_interp_points)
+            sample_interp_k = get_sample_interp_k(self.grid_ds.Z, self.ds[self.depth_str], self.num_interp_points)
             self.ds[f'{self.interp_str}_interp_k'] = (self.dims_interp, sample_interp_k)
 
         self.get_sample_type 

--- a/obsprep/utils.py
+++ b/obsprep/utils.py
@@ -223,20 +223,43 @@ def patchface3D(fldin,nx,nz):
 
 def get_sample_type(ds, fld):
 
-    # Map field types to factors
-    factor_map = {
-        'T': 1,
-        'S': 2,
-        'U': 3,
-        'V': 4,
-        'SSH': 5
-    }
-
     # Get the factor using the dictionary, default to 0 if fld is not found
-    fac = factor_map.get(fld, 0)
+    fac = field_map.get(fld, 0)
 
     # Create the sample_type variable
     sample_type = (fac * np.ones_like(ds.sample_lat.values)).astype(int)
     ds['sample_type'] = ("iSAMPLE", sample_type) 
 
     return ds
+
+
+grid_map = {
+    'C': {'grid_lon': 'XC', 'grid_lat': 'YC', 'mask': 'maskC'},
+    'W': {'grid_lon': 'XG', 'grid_lat': 'YC', 'mask': 'maskW'},
+    'S': {'grid_lon': 'XC', 'grid_lat': 'YG', 'mask': 'maskS'},
+}
+
+field_data = {
+    'T': {'sample_type': 1, 'mask_sfx': 'C'},
+    'S': {'sample_type': 2, 'mask_sfx': 'C'},
+    'U': {'sample_type': 3, 'mask_sfx': 'W'},
+    'V': {'sample_type': 4, 'mask_sfx': 'S'},
+    'SSH': {'sample_type': 5, 'mask_sfx': 'C'}
+}
+
+field_map = {
+    field: {
+        'sample_type': data['sample_type'],
+        'mask': grid_map[data['mask_sfx']]['mask'],
+        'grid_lon': grid_map[data['mask_sfx']]['grid_lon'],
+        'grid_lat': grid_map[data['mask_sfx']]['grid_lat']
+    }
+    for field, data in field_data.items()
+}
+
+def get_mask_sfx_from_sample_type(sample_types):
+    sample_type_to_mask_sfx = {data['sample_type']: data['mask_sfx'] for data in field_data.values()}
+
+    # Retrieve corresponding sample codes
+    mask_sfxs = [sample_type_to_mask_sfx[stype] for stype in sample_types]
+    return mask_sfxs

--- a/tutorials/obsprep_tutorial.ipynb
+++ b/tutorials/obsprep_tutorial.ipynb
@@ -33,7 +33,9 @@
     "import obsprep as op\n",
     "from obsprep.utils import generate_random_points\n",
     "\n",
-    "np.random.seed(3)"
+    "np.random.seed(3)\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
    ]
   },
   {
@@ -71,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nobs = 10\n",
+    "nobs = 1000\n",
     "lons, lats, depths = generate_random_points(nobs)"
    ]
   },
@@ -109,7 +111,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "OP.ds['sample_type'] = ('iSAMPLE', np.ones(nobs))\n",
     "OP.get_obs_point(lons, lats, depths, grid_type='llc', grid_ds=grid_ds, num_interp_points=1, sNx=30, sNy=30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa75561d-b8a1-4462-a41e-b8722133f2c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = OP.ds.copy()\n",
+    "plt.scatter(ds.sample_lon, ds.sample_lat)\n",
+    "plt.scatter(ds.sample_interp_XC11, ds.sample_interp_YC11, c=ds.sample_interp_XC11)"
    ]
   },
   {
@@ -245,20 +260,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "62e73040-06f2-4fcb-b681-c0f8ea1cd0ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "ds_in = ds_in.drop(['sample_type', 'obs_date', 'obs_YYYYMMDD', 'obs_HHMMSS', 'sample_point', 'sample_interp_XC11', 'sample_interp_YC11', 'sample_interp_XCNINJ', 'sample_interp_YCNINJ', 'sample_interp_i', 'sample_interp_j', 'sample_interp_weights'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d350df2-24dd-4a68-afa4-ec366328c4bb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c45a943c-8d55-4d0e-93dc-2ec86e917c56",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds_in = xr.Dataset(\n",
-    "    {\n",
-    "        'sample_lon': (('iSAMPLE',), lons),\n",
-    "        'sample_lat': (('iSAMPLE',), lats),\n",
-    "        'sample_depth': (('iSAMPLE',), depths),\n",
-    "        'obs_datetime': (('iSAMPLE',), obs_datetime),\n",
-    "        'obs_val': (('iSAMPLE',), theta_data)\n",
-    "    },\n",
-    ")\n",
+    "# ds_in = xr.Dataset(\n",
+    "#     {\n",
+    "#         'sample_lon': (('iSAMPLE',), lons),\n",
+    "#         'sample_lat': (('iSAMPLE',), lats),\n",
+    "#         'sample_depth': (('iSAMPLE',), depths),\n",
+    "#         'obs_datetime': (('iSAMPLE',), obs_datetime),\n",
+    "#         'obs_val': (('iSAMPLE',), theta_data)\n",
+    "#     },\n",
+    "# )\n",
     "\n",
+    "ds_in = xr.open_dataset('~/Downloads/obsprep_swot_test.nc')\n",
+    "\n",
+    "ds_in = ds_in.drop(['sample_type', 'obs_date', 'obs_YYYYMMDD', 'obs_HHMMSS', 'sample_point', 'sample_interp_XC11', 'sample_interp_YC11', 'sample_interp_XCNINJ', 'sample_interp_YCNINJ', 'sample_interp_i', 'sample_interp_j', 'sample_interp_weights'])\n",
     "OP = op.Prep('obsfit', ds_in)\n",
     "OP.get_obs_point(grid_type='llc', grid_ds=grid_ds, num_interp_points=1, sNx=30, sNy=30)\n",
     "OP.get_obs_datetime(time_var = 'obs_datetime')\n",
@@ -270,10 +307,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae084356-71bd-46b2-959c-b3eff6ef4cf8",
+   "id": "975a0796-c479-4fda-9783-0520f4c77ec6",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "ds_mini = ds_in.isel(iOBS=slice(0, 3), iSAMPLE=slice(0, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1809f324-7f55-41fd-826e-6ad9ba374075",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_in = xr.open_dataset('~/Downloads/obsprep_swot_test.nc')\n",
+    "ds_in = ds_in.drop_vars(['sample_type', 'obs_date', 'obs_YYYYMMDD', 'obs_HHMMSS', 'sample_point', 'sample_interp_XC11', 'sample_interp_YC11', 'sample_interp_XCNINJ', 'sample_interp_YCNINJ', 'sample_interp_i', 'sample_interp_j', 'sample_interp_weights'])\n",
+    "ds_mini = ds_in.isel(iOBS=slice(0, 3), iSAMPLE=slice(0, 3))\n",
+    "OP = op.Prep('obsfit', ds_mini)\n",
+    "\n",
+    "OP.ds['sample_type'] = ('iSAMPLE', [1, 3, 4])\n",
+    "OP.get_obs_point(grid_type='llc', grid_ds=grid_ds, num_interp_points=4, sNx=30, sNy=30)\n"
+   ]
   }
  ],
  "metadata": {
@@ -292,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Removed `obs_point` refencing to worldmap view, now everything is done in 13-face indexing, which is easier for use with xmitgcm/ecco_v4_py. First draft of land masking, the key point being each observation type `T/S/U/V/SSH` exist on `C/C/W/S/C` grid, respectively. 